### PR TITLE
Add Ruby compatibility warning

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,9 @@ Use Bumbler to track the load progress of your [Bundler](http://gembundler.com/)
 
 
 ## Using Bumbler
+
+WARNING: Works only with ruby 1.9
+
 ### Step 1:
 
     gem install bumbler


### PR DESCRIPTION
in ruby 1.8, it exits with:

ruby: no such file to load -- bumbler/go (LoadError)
