### PR TITLE
Don't fail to start on non-Unix and check width on unix

### DIFF
--- a/lib/bumbler/progress.rb
+++ b/lib/bumbler/progress.rb
@@ -41,10 +41,6 @@ module Bumbler
         # No-op for now.
       end
 
-      def tty_width
-        `tput cols`.to_i || 80
-      end
-
       def bar(width)
         inner_size = width - 2
 
@@ -88,6 +84,42 @@ module Bumbler
         elsif @curr_item
           puts '%s %s' % [count, @curr_item[:name]]
         end
+      end
+      
+      # This code was copied and modified from Rake, available under MIT-LICENSE
+      # Copyright (c) 2003, 2004 Jim Weirich
+      def tty_width
+        return 80 unless unix?
+  
+        result = dynamic_width
+        (result < 20) ? 80 : result
+      rescue
+        80
+      end
+  
+      begin
+        require 'io/console'
+  
+        def dynamic_width
+          rows, columns = IO.console.winsize
+          columns
+        end
+      rescue LoadError
+        def dynamic_width
+          dynamic_width_stty.nonzero? || dynamic_width_tput
+        end
+  
+        def dynamic_width_stty
+          %x{stty size 2>/dev/null}.split[1].to_i
+        end
+  
+        def dynamic_width_tput
+          %x{tput cols 2>/dev/null}.to_i
+        end
+      end
+  
+      def unix?
+        RUBY_PLATFORM =~ /(aix|darwin|linux|(net|free|open)bsd|cygwin|solaris|irix|hpux)/i
       end
     end
   end


### PR DESCRIPTION
Currently bumbler fails to start on Windows with:

```
Errno::ENOENT: No such file or directory - tput
```

Applying Rake MIT code to allow more robust Unix width check and rescue on terminal width allows us to run `bumbler` on non-Unix environments, too.

Credit goes to Rake and [Ruby-Progressbar](https://github.com/jfelchner/ruby-progressbar/blob/master/lib/ruby-progressbar/length_calculator.rb#L27-L61)
