### PR TITLE
Ensure Bumbler sees explicitly required gems

### DIFF
--- a/lib/bumbler/bundler.rb
+++ b/lib/bumbler/bundler.rb
@@ -41,6 +41,9 @@ module Bumbler
           @gem_state[spec.name] = {}
           
           Array(spec.autorequire || spec.name).each do |path|
+            # Handle explicitly required gems
+            path = spec.name if path == true
+            
             @require_map[path] = spec.name
             @gem_state[spec.name][path] = false
           end

--- a/test/bumbler_test.rb
+++ b/test/bumbler_test.rb
@@ -16,6 +16,13 @@ describe Bumbler do
     result = sh "bundle exec ruby test.rb"
     result.strip.must_equal "(0/2)  fakegem\n(1/2)  bumbler"
   end
+  
+  it "includes gems that are explicitly required" do
+    File.write("Gemfile", "source 'https://rubygems.org'\ngem 'fakegem', path: '#{Bundler.root}/test/fakegem', require: true\ngem 'bumbler', path: '#{Bundler.root}'")
+    File.write("test.rb", "require 'bumbler/go'\nBundler.require")
+    result = sh "bundle exec ruby test.rb"
+    result.strip.must_equal "(0/2)  fakegem\n(1/2)  bumbler"
+  end
 
   describe "CLI" do
     def bumbler(command="", options={})


### PR DESCRIPTION
Some Gemfiles explicitly require gems using the `require: true` syntax. This is supported per the Bundler documentation. Previously these gems would be ignored by Bumbler. This PR fixes things so that Bumbler includes these gems in its scans again. Closes #21 